### PR TITLE
fix: Alicloud ACS-SSO response mode is 'StsToken' not 'STS'

### DIFF
--- a/commands/run.js
+++ b/commands/run.js
@@ -152,6 +152,8 @@ async function getCredential(profile, parent) {
       return new CredentialModel(response['access_key_id'], response['access_key_secret']);
     } else if (response.mode === 'STS') {
       return new CredentialModel(response['access_key_id'], response['access_key_secret'], response['security_token']);
+    } else if (response.mode === 'StsToken') {
+      return new CredentialModel(response['access_key_id'], response['access_key_secret'], response['sts_token']);
     }
     break;
   }


### PR DESCRIPTION
## Issue 

I was getting `the mode 'External' is not supported currently.` when using auth from SSO using `acs-sso login`. 


## Cause 

ACS SSO have the following response : 

```json
{
  "mode": "StsToken",
  "access_key_id": "STS.xxxxxxxx",
  "access_key_secret": "xxxxxxxxxx",
  "sts_token": "xxxxx"
}
```

## Fix

This PR allows to support response from `acs-sso` without dropping support for external sources that would return `STS` as mode value.