### PR TITLE
fix: add ALIBABA_CLOUD_xxx env var

### DIFF
--- a/commands/run.js
+++ b/commands/run.js
@@ -57,13 +57,16 @@ class CredentialModel {
   toEnv() {
     const result = {
       'ALIBABACLOUD_ACCESS_KEY_ID': this.id,
+      'ALIBABA_CLOUD_ACCESS_KEY_ID': this.id,
       'ALICLOUD_ACCESS_KEY_ID': this.id,
       'ALIBABACLOUD_ACCESS_KEY_SECRET': this.secret,
+      'ALIBABA_CLOUD_ACCESS_KEY_SECRET': this.secret,
       'ALICLOUD_ACCESS_KEY_SECRET': this.secret
     };
 
     if (this.token) {
       result['ALIBABACLOUD_SECURITY_TOKEN'] = this.token;
+      result['ALIBABA_CLOUD_SECURITY_TOKEN'] = this.token;
       result['ALICLOUD_SECURITY_TOKEN'] = this.token;
       result['SECURITY_TOKEN'] = this.token;
     }


### PR DESCRIPTION
Some tools from Alicloud, for exemple [aliyun-odps-console](https://github.com/aliyun/aliyun-odps-console) expect some env var in the format ALIBABA_CLOUD_xxx 

Ref : https://github.com/aliyun/aliyun-odps-console/blob/a2f8d058bce18d58a00812f0235e07637454c580/odps-console-basic/src/main/java/com/aliyun/openservices/odps/console/commands/KonfigFromSysEnvCommand.java#L38

This PR add this type of variable to the env vars.  